### PR TITLE
Fix: Fixed body width (980px)

### DIFF
--- a/autoload/server/static/styles/markdown/markdown.css
+++ b/autoload/server/static/styles/markdown/markdown.css
@@ -1,5 +1,4 @@
 body {
-    width: 980px;
     margin: 20px auto;
     color: #333333;
     border: 1px solid #CCCCCC;


### PR DESCRIPTION
# Problem:
When zooming into the preview the fixed body width inhibits the browser from wrapping the text correctly. Thus, the zoomed piece of prose becomes incomprehensible. This is especially a problem on HiDPI devices.

# Solution:
The removal of the fixed width allows the browser to wrap the text correctly.

# (Pull request only)Here a quick demonstration:

## Problem: Fixed width:
![image](https://cloud.githubusercontent.com/assets/1167114/24845639/1c81145c-1db4-11e7-97cb-ddd73e911eba.png)

## Solution: After applying the fix:
![image](https://cloud.githubusercontent.com/assets/1167114/24845652/33f15098-1db4-11e7-8275-a4f7c5b2ef35.png)

