### PR TITLE
add default open browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Plug 'iamcco/markdown-preview.vim'
 > when MarkdownPreview command can't open preview window, you can use the
 MarkdownPreviewStop command before using MarkdownPreview command
 
-**Defaul Setting:**
+**Default Setting:**
 
 ```
     let g:mkdp_path_to_chrome = "google-chrome"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ MarkdownPreviewStop command before using MarkdownPreview command
     let g:mkdp_path_to_chrome = "google-chrome"
     " path to the chrome or the command to open chrome(or other modern browsers)
 
+    let g:mkdp_browserfunc = 'MKDP_browserfunc_default'
+    " callback vim function to open browser, the only param is the url to open
+    " if set, g:mkdp_path_to_chrome would be ignored
+
     let g:mkdp_auto_start = 0
     " set to 1, the vim will open the preview window once enter the markdown
     " buffer
@@ -159,6 +163,10 @@ Plug 'iamcco/markdown-preview.vim'
 ```
     let g:mkdp_path_to_chrome = "google-chrome"
     " 设置 chrome 浏览器的路径（或是启动 chrome（或其他现代浏览器）的命令）
+
+    let g:mkdp_browserfunc = 'MKDP_browserfunc_default'
+    " vim 回调函数, 参数为要打开的 url
+    " 如果设置了该参数, g:mkdp_path_to_chrome 将被忽略
 
     let g:mkdp_auto_start = 0
     " 设置为 1 可以在打开 markdown 文件的时候自动打开浏览器预览，只在打开

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ MarkdownPreviewStop command before using MarkdownPreview command
 **Default Setting:**
 
 ```
-    let g:mkdp_path_to_chrome = "google-chrome"
+    let g:mkdp_path_to_chrome = ""
     " path to the chrome or the command to open chrome(or other modern browsers)
+    " if set, g:mkdp_browserfunc would be ignored
 
     let g:mkdp_browserfunc = 'MKDP_browserfunc_default'
     " callback vim function to open browser, the only param is the url to open
-    " if set, g:mkdp_path_to_chrome would be ignored
 
     let g:mkdp_auto_start = 0
     " set to 1, the vim will open the preview window once enter the markdown
@@ -161,12 +161,12 @@ Plug 'iamcco/markdown-preview.vim'
 **默认配置：**
 
 ```
-    let g:mkdp_path_to_chrome = "google-chrome"
+    let g:mkdp_path_to_chrome = ""
     " 设置 chrome 浏览器的路径（或是启动 chrome（或其他现代浏览器）的命令）
+    " 如果设置了该参数, g:mkdp_browserfunc 将被忽略
 
     let g:mkdp_browserfunc = 'MKDP_browserfunc_default'
     " vim 回调函数, 参数为要打开的 url
-    " 如果设置了该参数, g:mkdp_path_to_chrome 将被忽略
 
     let g:mkdp_auto_start = 0
     " 设置为 1 可以在打开 markdown 文件的时候自动打开浏览器预览，只在打开

--- a/autoload/mkdp.vim
+++ b/autoload/mkdp.vim
@@ -123,10 +123,14 @@ fun! s:browserStart() abort "function for opening the browser
         exec s:py_cmd . 'vim.command("let g:mkdp_cwd = \"" + base64.b64encode(vim.eval("g:mkdp_cwd").encode("utf-8")).decode("utf-8") + "\"")'
     endif
 
-    if s:mkdp_is_windows()
-        exec "silent !start " . g:mkdp_path_to_chrome . " http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd
+    if exists('g:mkdp_browserfunc') && len(g:mkdp_browserfunc) > 0
+        execute 'call ' . g:mkdp_browserfunc . '("' . "http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . '")'
     else
-        call system(g:mkdp_path_to_chrome . " \"http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . "\" >/dev/null 2>&1 &")
+        if s:mkdp_is_windows()
+            exec "silent !start " . g:mkdp_path_to_chrome . " http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd
+        else
+            call system(g:mkdp_path_to_chrome . " \"http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . "\" &>/dev/null &")
+        endif
     endif
 endfun
 

--- a/autoload/mkdp.vim
+++ b/autoload/mkdp.vim
@@ -98,7 +98,7 @@ fun! s:serverStart() abort "function for starting the server
     if s:mkdp_is_windows()
         exec "silent !start /b python " . '"' . s:path_to_server . '" ' . g:mkdp_port
     else
-        call system("python " . s:path_to_server . " " . g:mkdp_port . " &>/dev/null &")
+        call system("python " . s:path_to_server . " " . g:mkdp_port . " >/dev/null 2>&1 &")
     endif
 endfun
 
@@ -126,7 +126,7 @@ fun! s:browserStart() abort "function for opening the browser
     if s:mkdp_is_windows()
         exec "silent !start " . g:mkdp_path_to_chrome . " http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd
     else
-        call system(g:mkdp_path_to_chrome . " \"http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . "\" &>/dev/null &")
+        call system(g:mkdp_path_to_chrome . " \"http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . "\" >/dev/null 2>&1 &")
     endif
 endfun
 

--- a/autoload/mkdp.vim
+++ b/autoload/mkdp.vim
@@ -123,14 +123,16 @@ fun! s:browserStart() abort "function for opening the browser
         exec s:py_cmd . 'vim.command("let g:mkdp_cwd = \"" + base64.b64encode(vim.eval("g:mkdp_cwd").encode("utf-8")).decode("utf-8") + "\"")'
     endif
 
-    if exists('g:mkdp_browserfunc') && len(g:mkdp_browserfunc) > 0
-        execute 'call ' . g:mkdp_browserfunc . '("' . "http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . '")'
-    else
+    if exists('g:mkdp_path_to_chrome') && len(g:mkdp_path_to_chrome) > 0
         if s:mkdp_is_windows()
             exec "silent !start " . g:mkdp_path_to_chrome . " http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd
         else
-            call system(g:mkdp_path_to_chrome . " \"http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . "\" &>/dev/null &")
+            call system(g:mkdp_path_to_chrome . " \"http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . "\" >/dev/null 2>&1 &")
         endif
+    elseif exists('g:mkdp_browserfunc') && len(g:mkdp_browserfunc) > 0
+        execute 'call ' . g:mkdp_browserfunc . '("' . "http://127.0.0.1:" . g:mkdp_port . "/markdown/" . g:mkdp_prefix . bufnr('%') . '?' . g:mkdp_cwd . '")'
+    else
+        echo '[Plugin: markdown-preview]: g:mkdp_path_to_chrome or g:mkdp_browserfunc not set'
     endif
 endfun
 

--- a/autoload/server/static/scripts/index.js
+++ b/autoload/server/static/scripts/index.js
@@ -40,7 +40,7 @@
         var slash = getSlash();
         var bases = Base64.decode(base.slice(1)).split('&')[0].split(slash).slice(0, -1);
         var paths = path.split(slash);
-        if(/^https?:?/i.test(paths[0])) {
+        if(/^https?:?/i.test(paths[0]) || /^\/DIYURL?.*$/.test(path)) {
             return path;
         } else if(/^$|^[a-zA-Z]:.*$/.test(paths[0])) {
             return '/DIYURL?' + Base64.encode(path);

--- a/doc/mkdp.txt
+++ b/doc/mkdp.txt
@@ -27,12 +27,12 @@ Command：
 
 Defaul Setting:
 
-    g:mkdp_path_to_chrome = "google-chrome"
+    g:mkdp_path_to_chrome = ""
     " path to the chrome or the command to open chrome
+    " if set, g:mkdp_browserfunc would be ignored
 
     let g:mkdp_browserfunc = 'MKDP_browserfunc_default'
     " callback vim function to open browser, the only param is the url to open
-    " if set, g:mkdp_path_to_chrome would be ignored
 
     g:mkdp_auto_start = 0
     " set to 1, the vim will open the preview window once enter the markdown
@@ -103,12 +103,12 @@ A: if you want the plugin auto close the preview window on firefox, you have to 
 
 默认配置：
 
-    g:mkdp_path_to_chrome = "google-chrome"
+    g:mkdp_path_to_chrome = ""
     " 设置 chrome 浏览器的路径（或是启动 chrome 的命令）
+    " 如果设置了该参数, g:mkdp_browserfunc 将被忽略
 
     let g:mkdp_browserfunc = 'MKDP_browserfunc_default'
     " vim 回调函数, 参数为要打开的 url
-    " 如果设置了该参数, g:mkdp_path_to_chrome 将被忽略
 
     g:mkdp_auto_start = 0
     " 设置为 1 可以在打开 markdown 文件的时候自动打开浏览器预览，只在打开

--- a/doc/mkdp.txt
+++ b/doc/mkdp.txt
@@ -30,6 +30,10 @@ Defaul Setting:
     g:mkdp_path_to_chrome = "google-chrome"
     " path to the chrome or the command to open chrome
 
+    let g:mkdp_browserfunc = 'MKDP_browserfunc_default'
+    " callback vim function to open browser, the only param is the url to open
+    " if set, g:mkdp_path_to_chrome would be ignored
+
     g:mkdp_auto_start = 0
     " set to 1, the vim will open the preview window once enter the markdown
     buffer
@@ -101,6 +105,10 @@ A: if you want the plugin auto close the preview window on firefox, you have to 
 
     g:mkdp_path_to_chrome = "google-chrome"
     " 设置 chrome 浏览器的路径（或是启动 chrome 的命令）
+
+    let g:mkdp_browserfunc = 'MKDP_browserfunc_default'
+    " vim 回调函数, 参数为要打开的 url
+    " 如果设置了该参数, g:mkdp_path_to_chrome 将被忽略
 
     g:mkdp_auto_start = 0
     " 设置为 1 可以在打开 markdown 文件的时候自动打开浏览器预览，只在打开

--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -20,7 +20,7 @@ set cpo&vim
 "default setting
 
 if !exists('g:mkdp_path_to_chrome')
-    let g:mkdp_path_to_chrome = 'google-chrome'
+    let g:mkdp_path_to_chrome = '' " 'google-chrome'
 endif
 
 if !exists('g:mkdp_auto_start')

--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -43,6 +43,25 @@ if !exists('g:mkdp_command_for_global')
     let g:mkdp_command_for_global = 0
 endif
 
+function! MKDP_browserfunc_default(url)
+    if has("win32") || has("win64")
+        " windows
+        execute "silent !cmd /c start " . a:url . '.html'
+    elseif has("unix")
+        silent! let s:uname=system("uname")
+        if s:uname=="Darwin\n"
+            " mac
+            let dummy = system('open "' . a:url . '"')
+        else
+            " unix
+            let dummy = system('xdg-open "' . a:url . '"')
+        endif
+    endif
+endfunction
+if !exists('g:mkdp_browserfunc')
+    let g:mkdp_browserfunc='MKDP_browserfunc_default'
+endif
+
 let g:mkdp_server_started = 0
 
 fu! s:serverStart() abort


### PR DESCRIPTION
no need to specify g:mkdp_path_to_chrome any more, the default behavior of g:mkdp_browserfunc would suit for most case, and properly open system's default browser by default

tested under Windows and mac OS