### PR TITLE
Fix: duplicated base64 encoding

### DIFF
--- a/autoload/server/static/scripts/index.js
+++ b/autoload/server/static/scripts/index.js
@@ -40,7 +40,7 @@
         var slash = getSlash();
         var bases = Base64.decode(base.slice(1)).split('&')[0].split(slash).slice(0, -1);
         var paths = path.split(slash);
-        if(/^https?:?/i.test(paths[0])) {
+        if(/^https?:?/i.test(paths[0]) || /^\/DIYURL?.*$/.test(path)) {
             return path;
         } else if(/^$|^[a-zA-Z]:.*$/.test(paths[0])) {
             return '/DIYURL?' + Base64.encode(path);


### PR DESCRIPTION
## Problem

The path of images in the following case will be encoded twice.

```markdown
BUG EMERSION
============

1. test
	1. ![Tux_Mono](./Tux_Mono.png)
	1. <img src='./Tux_Mono.png' width='10%'>
	1. test
```

The path is supposed to be `/DIYURL?L3RtcC9UdXhfTW9uby5wbmc=` instead of `/DIYURL?L0RJWVVSTD9MM1J0Y0M5VWRYaGZUVzl1Ynk1d2JtYz0=` in the generated page.

![markdown-preview-vim-bug](https://user-images.githubusercontent.com/9400582/31496309-745cba08-af8d-11e7-9fa9-a933ffc75e71.png)

## Solution
In function `getAbsPath`, `path` should be returned directly if it starts with `/DIYURL?`.
![bug-fix](https://user-images.githubusercontent.com/9400582/31496316-7ad771c0-af8d-11e7-879f-80f7cc06b4cd.png)
