### PR TITLE
Fix python module path in git-bash && Add sync in browser opening

### DIFF
--- a/autoload/mkdp.vim
+++ b/autoload/mkdp.vim
@@ -40,7 +40,10 @@ let g:mkdp_cwd = ''
 "python/python3 import init
 exec s:py_cmd . 'import vim'
 exec s:py_cmd . 'import sys'
+exec s:py_cmd . 'import os'
+exec s:py_cmd . 'import re'
 exec s:py_cmd . 'cwd = vim.eval("expand(\"<sfile>:p:h\")")'
+exec s:py_cmd . "cwd = re.sub(r'(?<=^.)', r':', os.sep.join(cwd.split('/')[1:])) if os.name == 'nt' and cwd.startswith('/') else cwd"
 exec s:py_cmd . 'sys.path.insert(0,cwd)'
 exec s:py_cmd . 'from server import send'
 exec s:py_cmd . 'import base64'

--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -44,18 +44,29 @@ if !exists('g:mkdp_command_for_global')
 endif
 
 function! MKDP_browserfunc_default(url)
-    if has("win32") || has("win64")
-        " windows
-        execute "silent !cmd /c start " . a:url . '.html'
-    elseif has("unix")
-        silent! let s:uname=system("uname")
-        if s:uname=="Darwin\n"
-            " mac
-            let dummy = system('open "' . a:url . '"')
-        else
-            " unix
-            let dummy = system('xdg-open "' . a:url . '"')
-        endif
+    " windows, including mingw
+    if has('win32') || has('win64') || has('win32unix')
+        let l:cmd = "start " . a:url . '.html'
+    " mac os
+    elseif has('mac') || has('macunix') || has('gui_macvim') || system('uname') =~? '^darwin'
+        let l:cmd = 'open ' . a:url
+    " linux
+    elseif executable('xdg-open')
+        let l:cmd = 'xdg-open ' . a:url
+    " can not find the browser
+    else
+        echoerr "Browser not found."
+        return
+    endif
+
+    " Async open the url in browser
+    if exists('*jobstart')
+        call jobstart(l:cmd)
+    elseif exists('*job_start')
+        call job_start(l:cmd)
+    else
+    " if async is not supported, use `system` command
+        call system(l:cmd)
     endif
 endfunction
 if !exists('g:mkdp_browserfunc')


### PR DESCRIPTION
- 在 Windows 下使用 gitbash 自带的 Vim 8.0 预览 Markdown 时，报错 `No module named server` . 这是因为 git bash 的路径命名和 Windows 本身的有所不同，主要是比如说它把 C 盘盘符识别为 `/c/...` 而不是 `C:\...`，所以在这是更改一下 `cwd`. 类似的情况参见 https://github.com/Yggdroot/LeaderF/issues/206
https://github.com/iamcco/markdown-preview.vim/blob/c09a1cad5da33602344027367a57814d0c283078/autoload/mkdp.vim#L43

- 改进了不同平台打开浏览器方式的判断。
- 为 `MKDP_browserfunc_default` 函数增加了异步方法，解决了打开浏览器后需要 `redraw` 的问题（至少对我而言是这样），参见 #65 