### PR TITLE
修复linux下无法预览的bug

### DIFF
--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -80,7 +80,7 @@ function! MKDP_browserfunc_default(url)
         call timer_start(get(g:, 'mkdp_delay_start_browser', 200), function('s:start_cmd'))
     else
     " if async is not supported, use `system` command
-        call system(l:cmd)
+        call system(s:start_cmd_value)
     endif
 endfunction
 if !exists('g:mkdp_browserfunc')


### PR DESCRIPTION
Linux下预览时，会报下面的错误
```
Error detected while processing function <SNR>13_serverStart..mkdp#browserStart..<SNR>32_browserStart..MKDP_browserfunc_default:
line   30:
E121: Undefined variable: l:cmd
E116: Invalid arguments for function system
```
原因是l:cmd变量未定义，这个变量名已经改为了s:start_cmd_value